### PR TITLE
add top level 'MessageText' element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -88,6 +88,26 @@ Object {
 }
 `;
 
+exports[`slack jsx message with complex fallback text 1`] = `
+Object {
+  "as_user": false,
+  "blocks": Array [],
+  "mrkdwn": true,
+  "response_type": "in_channel",
+  "text": "Hey <@foo>progress: \`▓▓▓▓▓▓▓░░░\`",
+}
+`;
+
+exports[`slack jsx message with simple fallback text 1`] = `
+Object {
+  "as_user": false,
+  "blocks": Array [],
+  "mrkdwn": false,
+  "response_type": "in_channel",
+  "text": "simple message text",
+}
+`;
+
 exports[`slack jsx renders ActionsBlock elements as children 1`] = `
 Object {
   "elements": Array [

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -13,19 +13,19 @@ import {
   Mention,
   ProgressBar,
   Message,
-  MessageText,
+  AltText,
 } from '..';
 
 describe('slack jsx', () => {
   it('message with complex fallback text', () => {
     const message = (
       <Message
-        text={
-          <MessageText>
+        altText={
+          <AltText>
             Hey <Mention userId="foo" />
             progress:{' '}
             <ProgressBar columnWidth={10} total={300} value={200} color="red" />
-          </MessageText>
+          </AltText>
         }
       ></Message>
     );
@@ -35,7 +35,7 @@ describe('slack jsx', () => {
   it('message with simple fallback text', () => {
     const message = (
       <Message
-        text={<MessageText mrkdwn={false}>simple message text</MessageText>}
+        altText={<AltText mrkdwn={false}>simple message text</AltText>}
       ></Message>
     );
     expect(message).toMatchSnapshot();

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -13,9 +13,34 @@ import {
   Mention,
   ProgressBar,
   Message,
+  MessageText,
 } from '..';
 
 describe('slack jsx', () => {
+  it('message with complex fallback text', () => {
+    const message = (
+      <Message
+        text={
+          <MessageText>
+            Hey <Mention userId="foo" />
+            progress:{' '}
+            <ProgressBar columnWidth={10} total={300} value={200} color="red" />
+          </MessageText>
+        }
+      ></Message>
+    );
+    expect(message).toMatchSnapshot();
+  });
+
+  it('message with simple fallback text', () => {
+    const message = (
+      <Message
+        text={<MessageText mrkdwn={false}>simple message text</MessageText>}
+      ></Message>
+    );
+    expect(message).toMatchSnapshot();
+  });
+
   it('component with single string child', () => {
     const message = <PlainText>fooooo</PlainText>;
     expect(message).toMatchSnapshot();

--- a/src/components/Message.ts
+++ b/src/components/Message.ts
@@ -11,7 +11,7 @@ export interface MessageProps
   channel?: string;
   token?: string;
   asUser?: boolean;
-  text?: MessageTextProps;
+  altText?: MessageTextProps;
 }
 
 export interface MessageSpec {
@@ -28,7 +28,7 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   responseType = 'in_channel',
   channel,
   token,
-  text,
+  altText,
   asUser = false,
 }) => ({
   response_type: responseType,
@@ -36,5 +36,5 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   as_user: asUser,
   channel,
   token,
-  ...text,
+  ...altText,
 });

--- a/src/components/Message.ts
+++ b/src/components/Message.ts
@@ -1,6 +1,7 @@
 import { FC } from '..';
 import { ContainerProps } from './ContainerProps';
 import { Block } from './Block';
+import { MessageTextProps } from './MessageText';
 
 export type MessageType = 'ephemeral' | 'in_channel';
 
@@ -10,6 +11,7 @@ export interface MessageProps
   channel?: string;
   token?: string;
   asUser?: boolean;
+  text?: MessageTextProps;
 }
 
 export interface MessageSpec {
@@ -18,6 +20,7 @@ export interface MessageSpec {
   as_user?: boolean;
   token?: string;
   blocks?: Block<any, any>[];
+  text?: string;
 }
 
 export const Message: FC<MessageProps, MessageSpec> = ({
@@ -25,6 +28,7 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   responseType = 'in_channel',
   channel,
   token,
+  text,
   asUser = false,
 }) => ({
   response_type: responseType,
@@ -32,4 +36,5 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   as_user: asUser,
   channel,
   token,
+  ...text,
 });

--- a/src/components/MessageText.ts
+++ b/src/components/MessageText.ts
@@ -1,0 +1,19 @@
+// https://api.slack.com/reference/messaging/payload
+import {
+  TextProps,
+  MessageText as Text,
+  joinTextChildren,
+  MessageTextSpec
+} from './Text';
+
+export interface MessageTextProps extends TextProps {
+  mrkdwn?: boolean;
+}
+
+export const MessageText: Text<MessageTextProps, MessageTextSpec> = ({
+  children,
+  mrkdwn = true
+}) => ({
+  mrkdwn,
+  text: joinTextChildren(children)
+});

--- a/src/components/MessageText.ts
+++ b/src/components/MessageText.ts
@@ -3,17 +3,17 @@ import {
   TextProps,
   MessageText as Text,
   joinTextChildren,
-  MessageTextSpec
+  MessageTextSpec,
 } from './Text';
 
 export interface MessageTextProps extends TextProps {
   mrkdwn?: boolean;
 }
 
-export const MessageText: Text<MessageTextProps, MessageTextSpec> = ({
+export const AltText: Text<MessageTextProps, MessageTextSpec> = ({
   children,
-  mrkdwn = true
+  mrkdwn = true,
 }) => ({
   mrkdwn,
-  text: joinTextChildren(children)
+  text: joinTextChildren(children),
 });

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -4,6 +4,9 @@ import { ContainerProps } from './ContainerProps';
 
 // https://api.slack.com/reference/messaging/composition-objects#text
 
+// custom 'spec' since this isn't defined in '@slack/types'
+export type MessageTextSpec = { text: string; mrkdwn: boolean };
+
 export type TextType = 'plain_text' | 'mrkdwn';
 
 export type TextProps = ContainerProps<string>;
@@ -11,6 +14,11 @@ export type TextProps = ContainerProps<string>;
 export type TextElementSpec = MrkdwnElement | PlainTextElement;
 
 export type Text<P extends TextProps, E extends TextElementSpec> = FC<P, E>;
+
+export type MessageText<P extends TextProps, E extends MessageTextSpec> = FC<
+  P,
+  E
+>;
 
 export const joinTextChildren = (children: string | string[]) =>
   [].concat(children).join('');

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,7 +11,7 @@ export { ImageElement } from './ImageElement';
 
 export { PlainText } from './PlainText';
 export { MarkdownText } from './MarkdownText';
-export { MessageText } from './MessageText';
+export { AltText } from './MessageText';
 
 export { Link } from './Link';
 export { Mention } from './Mention';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { ImageElement } from './ImageElement';
 
 export { PlainText } from './PlainText';
 export { MarkdownText } from './MarkdownText';
+export { MessageText } from './MessageText';
 
 export { Link } from './Link';
 export { Mention } from './Mention';


### PR DESCRIPTION
closes: #10 

the more i think about this, the more i think it would make sense as a property of `Message`

Pros:
* it is at the same hierarchical level as other message props (channel, token, etc)
* easier to make it a `required` value since this required in the [message payload](https://api.slack.com/reference/messaging/payload)

Cons:
* i don't like verbose text props, but i guess this shouldn't be verbose anyway....
