### PR TITLE
add modal component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/components/Message.ts
+++ b/src/components/Message.ts
@@ -32,7 +32,6 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   altText,
   asUser = false,
 }) => {
-  console.log(children);
   return {
     response_type: responseType,
     blocks: Array.isArray(children) ? children : [].concat(children),

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -1,30 +1,26 @@
 import { FC } from '..';
 import { ContainerProps } from './ContainerProps';
 import { Block } from './Block';
-import { KnownBlock } from '@slack/types';
-import { ModalType } from './Text';
+import { KnownBlock, View } from '@slack/types';
 
 export interface ModalProps
   extends ContainerProps<ReturnType<Block<any, KnownBlock>>> {
   callbackId: string;
   title: string;
-  type: ModalType;
 }
 
-export interface ModalSpec {
-  callback_id: string;
-  type: ModalType;
-  blocks: ReturnType<Block<any, KnownBlock>>[];
+export interface ModalSpec
+  extends Pick<View, 'callback_id' | 'blocks' | 'title'> {
+  type: 'modal';
 }
 
 export const Modal: FC<ModalProps, ModalSpec> = ({
   children,
   callbackId,
   title,
-  type,
 }) => {
   return {
-    type: type,
+    type: 'modal',
     callback_id: callbackId,
     blocks: Array.isArray(children) ? children : [].concat(children),
     title: { type: 'plain_text', text: title },

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -1,0 +1,30 @@
+import { FC } from '..';
+import { ContainerProps } from './ContainerProps';
+import { Block } from './Block';
+import { KnownBlock } from '@slack/types';
+
+export type ModalType = 'ephemeral';
+
+export interface ModaleProps
+  extends ContainerProps<ReturnType<Block<any, KnownBlock>>> {
+  callbackId: string;
+  title: string;
+}
+
+export interface ModalSpec {
+  callback_id: string;
+  blocks?: ReturnType<Block<any, KnownBlock>>[];
+}
+
+export const Modal: FC<ModaleProps, ModalSpec> = ({
+  children,
+  callbackId,
+  title,
+}) => {
+  return {
+    type: 'modal',
+    callback_id: callbackId,
+    blocks: Array.isArray(children) ? children : [].concat(children),
+    title: { type: 'plain_text', text: title },
+  };
+};

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -4,7 +4,7 @@ import { Block } from './Block';
 import { KnownBlock } from '@slack/types';
 import { ModalType } from './Text';
 
-export interface ModaleProps
+export interface ModalProps
   extends ContainerProps<ReturnType<Block<any, KnownBlock>>> {
   callbackId: string;
   title: string;
@@ -17,7 +17,7 @@ export interface ModalSpec {
   blocks: ReturnType<Block<any, KnownBlock>>[];
 }
 
-export const Modal: FC<ModaleProps, ModalSpec> = ({
+export const Modal: FC<ModalProps, ModalSpec> = ({
   children,
   callbackId,
   title,

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -2,27 +2,29 @@ import { FC } from '..';
 import { ContainerProps } from './ContainerProps';
 import { Block } from './Block';
 import { KnownBlock } from '@slack/types';
-
-export type ModalType = 'ephemeral';
+import { ModalType } from './Text';
 
 export interface ModaleProps
   extends ContainerProps<ReturnType<Block<any, KnownBlock>>> {
   callbackId: string;
   title: string;
+  type: ModalType;
 }
 
 export interface ModalSpec {
   callback_id: string;
-  blocks?: ReturnType<Block<any, KnownBlock>>[];
+  type: ModalType;
+  blocks: ReturnType<Block<any, KnownBlock>>[];
 }
 
 export const Modal: FC<ModaleProps, ModalSpec> = ({
   children,
   callbackId,
   title,
+  type,
 }) => {
   return {
-    type: 'modal',
+    type: type,
     callback_id: callbackId,
     blocks: Array.isArray(children) ? children : [].concat(children),
     title: { type: 'plain_text', text: title },

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -9,8 +9,6 @@ export type MessageTextSpec = { text: string; mrkdwn: boolean };
 
 export type TextType = 'plain_text' | 'mrkdwn';
 
-export type ModalType = 'modal' | 'home';
-
 export type TextProps = ContainerProps<string>;
 
 export type TextElementSpec = MrkdwnElement | PlainTextElement;

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -9,6 +9,8 @@ export type MessageTextSpec = { text: string; mrkdwn: boolean };
 
 export type TextType = 'plain_text' | 'mrkdwn';
 
+export type ModalType = 'modal' | 'home';
+
 export type TextProps = ContainerProps<string>;
 
 export type TextElementSpec = MrkdwnElement | PlainTextElement;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { Message, MessageSpec, MessageProps } from './Message';
 
+export { Modal, ModalSpec } from './Modal';
 export { ActionsBlock } from './ActionsBlock';
 export { ContextBlock } from './ContextBlock';
 export { DividerBlock } from './DividerBlock';


### PR DESCRIPTION
add top level Modal component so people can make use of https://api.slack.com/surfaces/modals

modals are a popup window that can be interacted with outside of a message thread 
<img width="460" alt="image" src="https://user-images.githubusercontent.com/16813106/74794188-6bb79280-5277-11ea-8aa2-7116c25dd977.png">

closes: #23 