### PR TITLE
add input block and plain-text-input element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/components/InputBlock.ts
+++ b/src/components/InputBlock.ts
@@ -1,0 +1,18 @@
+import { Block, BlockProps } from './Block';
+import { InputBlock as InputBlockSpec } from '@slack/types';
+import { ContainerProps } from './ContainerProps';
+
+export interface InputBlockProps extends BlockProps, ContainerProps<any> {
+  label: string;
+}
+
+export const InputBlock: Block<InputBlockProps, InputBlockSpec> = ({
+  label,
+  blockId,
+  children,
+}) => ({
+  type: 'input',
+  label: { type: 'plain_text', text: label, emoji: true },
+  block_id: blockId,
+  element: children[0],
+});

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -7,24 +7,45 @@ import { KnownBlock, View } from '@slack/types';
 
 export interface ModalProps
   extends ContainerProps<ReturnType<Block<any, KnownBlock>>> {
-  callbackId: string;
   title: string;
+  callbackId?: string;
+  submitButtonText?: string;
+  closeButtonText?: string;
+  privateMetadata?: string;
+  clearOnClose?: boolean;
+  notifyOnClose?: boolean;
 }
 
-export interface ModalSpec
-  extends Pick<View, 'callback_id' | 'blocks' | 'title'> {
-  type: 'modal';
-}
+// TODO: maybe just rename Modal -> View. slack docs make this a bit confusing
+// in the meantime exporting this spec for consistency
+export type ModalSpec = View;
 
 export const Modal: FC<ModalProps, ModalSpec> = ({
   children,
   callbackId,
   title,
+  submitButtonText,
+  closeButtonText,
+  privateMetadata,
+  clearOnClose,
+  notifyOnClose,
 }) => {
-  return {
+  const modal: ModalSpec = {
     type: 'modal',
     callback_id: callbackId,
     blocks: Array.isArray(children) ? children : [].concat(children),
     title: { type: 'plain_text', text: title },
+    private_metadata: privateMetadata,
+    clear_on_close: clearOnClose,
+    notify_on_close: notifyOnClose,
   };
+
+  if (submitButtonText) {
+    modal.submit = { type: 'plain_text', text: submitButtonText };
+  }
+  if (closeButtonText) {
+    modal.close = { type: 'plain_text', text: closeButtonText };
+  }
+
+  return modal;
 };

--- a/src/components/PlainTextInputElement.ts
+++ b/src/components/PlainTextInputElement.ts
@@ -1,0 +1,35 @@
+import { FC } from '..';
+import { PlainTextInput as PlainTextInputSpec } from '@slack/types';
+
+export interface PlainTextInputProps {
+  placeholderText?: string;
+  initialValue?: string;
+  multiline?: boolean;
+  minLength?: number;
+  maxLength?: number;
+}
+
+export const PlainTextInputElement: FC<
+  PlainTextInputProps,
+  PlainTextInputSpec
+> = ({
+  placeholderText,
+  initialValue: initial_value,
+  multiline,
+  minLength: min_length,
+  maxLength: max_length,
+}) => {
+  const plainTextInput: PlainTextInputSpec = {
+    type: 'plain_text_input',
+    initial_value,
+    multiline,
+    min_length,
+    max_length,
+  };
+
+  if (placeholderText) {
+    plainTextInput.placeholder = { type: 'plain_text', text: placeholderText };
+  }
+
+  return plainTextInput;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,11 +4,13 @@ export { Modal, ModalSpec } from './Modal';
 export { ActionsBlock } from './ActionsBlock';
 export { ContextBlock } from './ContextBlock';
 export { DividerBlock } from './DividerBlock';
+export { InputBlock } from './InputBlock';
 export { SectionBlock } from './SectionBlock';
 export { ImageBlock } from './ImageBlock';
 
 export { ButtonElement } from './ButtonElement';
 export { ImageElement } from './ImageElement';
+export { PlainTextInputElement } from './PlainTextInputElement';
 
 export { PlainText } from './PlainText';
 export { MarkdownText } from './MarkdownText';


### PR DESCRIPTION
closes: #25 
adds a `Input` block level component as well as a `PlainTextInput` element component.

also some additions to `Modal` to support the optional `submit` and `close` props that are REQUIRED if you have any input options. maybe we should just always require those?