### PR TITLE
channel select element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/components/ChannelsSelect.ts
+++ b/src/components/ChannelsSelect.ts
@@ -1,0 +1,30 @@
+import { joinTextChildren } from './Text';
+import { ChannelsSelect as ChannelSelectSpec } from '@slack/types';
+import { ContainerProps } from './ContainerProps';
+import { FC } from '..';
+
+export interface ChannelSelectProps extends ContainerProps<string> {
+  initialChannel?: string;
+  actionId?: string;
+}
+
+export const ChannelSelect: FC<ChannelSelectProps, ChannelSelectSpec> = ({
+  children,
+  initialChannel,
+  actionId,
+}) => {
+  const select: ChannelSelectSpec = {
+    type: 'channels_select',
+    initial_channel: initialChannel,
+    action_id: actionId,
+  };
+
+  if (children) {
+    select.placeholder = {
+      type: 'plain_text',
+      text: joinTextChildren(children),
+    };
+  }
+
+  return select;
+};

--- a/src/components/PlainTextInputElement.ts
+++ b/src/components/PlainTextInputElement.ts
@@ -7,6 +7,7 @@ export interface PlainTextInputProps {
   multiline?: boolean;
   minLength?: number;
   maxLength?: number;
+  actionId?: string;
 }
 
 export const PlainTextInputElement: FC<
@@ -18,6 +19,7 @@ export const PlainTextInputElement: FC<
   multiline,
   minLength: min_length,
   maxLength: max_length,
+  actionId: action_id,
 }) => {
   const plainTextInput: PlainTextInputSpec = {
     type: 'plain_text_input',
@@ -25,6 +27,7 @@ export const PlainTextInputElement: FC<
     multiline,
     min_length,
     max_length,
+    action_id,
   };
 
   if (placeholderText) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { ImageBlock } from './ImageBlock';
 export { ButtonElement } from './ButtonElement';
 export { ImageElement } from './ImageElement';
 export { PlainTextInputElement } from './PlainTextInputElement';
+export { ChannelSelect } from './ChannelsSelect';
 
 export { PlainText } from './PlainText';
 export { MarkdownText } from './MarkdownText';


### PR DESCRIPTION
closes: #27 

add channel select input element for selecting a slack channel.
also minor update to add `action_id` to plain text input