### PR TITLE
only include 'as_user' when explicitly set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.3.1-0",
+  "version": "0.3.1",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.1-0",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`slack jsx can ignore falsy children 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "type": "divider",
@@ -22,7 +21,6 @@ Object {
 
 exports[`slack jsx can render nested fragments in maps 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "type": "divider",
@@ -159,7 +157,6 @@ Object {
 
 exports[`slack jsx can render simple fragments 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "type": "divider",
@@ -179,7 +176,6 @@ Object {
 
 exports[`slack jsx component with array of nested component children 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "text": Object {
@@ -269,7 +265,6 @@ Object {
 
 exports[`slack jsx flattens multiple sections in an array 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "text": Object {
@@ -312,7 +307,6 @@ Object {
 
 exports[`slack jsx message with complex fallback text 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [],
   "mrkdwn": true,
   "response_type": "in_channel",
@@ -322,11 +316,31 @@ Object {
 
 exports[`slack jsx message with simple fallback text 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [],
   "mrkdwn": false,
   "response_type": "in_channel",
   "text": "simple message text",
+}
+`;
+
+exports[`slack jsx only renders as_user when explicitly set 1`] = `
+Object {
+  "as_user": true,
+  "blocks": Array [
+    Object {
+      "text": Object {
+        "emoji": true,
+        "text": "sent as user",
+        "type": "plain_text",
+      },
+      "type": "section",
+    },
+  ],
+  "channel": "test_channel",
+  "mrkdwn": true,
+  "response_type": "in_channel",
+  "text": "as user",
+  "token": "test_token",
 }
 `;
 
@@ -354,7 +368,6 @@ Object {
 
 exports[`slack jsx renders a complex message 1`] = `
 Object {
-  "as_user": false,
   "blocks": Array [
     Object {
       "text": Object {

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -384,4 +384,20 @@ describe('slack jsx', () => {
 
     expect(await render(message)).toMatchSnapshot();
   });
+
+  it('only renders as_user when explicitly set', async () => {
+    const message = (
+      <Message
+        token="test_token"
+        channel="test_channel"
+        altText={<AltText>as user</AltText>}
+        asUser
+      >
+        <SectionBlock>
+          <PlainText emoji>sent as user</PlainText>
+        </SectionBlock>
+      </Message>
+    );
+    expect(await render(message)).toMatchSnapshot();
+  });
 });

--- a/src/components/Message.ts
+++ b/src/components/Message.ts
@@ -30,12 +30,19 @@ export const Message: FC<MessageProps, MessageSpec> = ({
   channel,
   token,
   altText,
-  asUser = false,
-}) => ({
-  response_type: responseType,
-  blocks: Array.isArray(children) ? children : [].concat(children),
-  as_user: asUser,
-  channel,
-  token,
-  ...altText,
-});
+  asUser,
+}) => {
+  const message = {
+    response_type: responseType,
+    blocks: Array.isArray(children) ? children : [].concat(children),
+    as_user: asUser,
+    channel,
+    token,
+    ...altText,
+  };
+
+  if (asUser) {
+    message.as_user = asUser;
+  }
+  return message;
+};


### PR DESCRIPTION
after migrating to slack's new auth flow and granular scopes (v2) https://api.slack.com/authentication/quickstart

the as_user param can no longer be used with bot tokens. they can only be used with user tokens. so we should not set this param by default. only set it if the user explicitly sets it. https://api.slack.com/methods/chat.postMessage

closes: #33 