### PR TITLE
realized a better way to do text components

### DIFF
--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`slack jsx renders inline text elements with promises returning text ele
 Object {
   "elements": Array [
     Object {
-      "text": "Hello, world! <@foo>,<@bar>",
+      "text": "Hello, world! <@foo><@bar>",
       "type": "mrkdwn",
       "verbatim": false,
     },

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -369,16 +369,14 @@ describe('slack jsx', () => {
   });
 
   it('renders inline text elements with promises returning text elements', async () => {
-    const renderText = async () => {
-      const strings = await Promise.all(
-        ['foo', 'bar'].map(s => render(<Mention userId={s} />))
-      );
-      return `world! ${strings}`;
+    const renderText = () => {
+      const strings = ['foo', 'bar'].map(s => <Mention userId={s} />);
+      return <>world! {strings}</>;
     };
 
     const message = (
       <ContextBlock>
-        <MarkdownText>Hello, {await renderText()}</MarkdownText>
+        <MarkdownText>Hello, {renderText()}</MarkdownText>
       </ContextBlock>
     );
 


### PR DESCRIPTION
yeah rather than force rendering into a template string, it makes sense to define text components as mixed text and elements inside a fragment.