### PR TITLE
add Checkbox input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",
@@ -23,7 +23,7 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "@slack/types": "1.7.0",
+    "@slack/types": "1.9.0",
     "lodash.flattendeep": "^4.4.0",
     "slackify-markdown": "3.0.3"
   },
@@ -34,7 +34,7 @@
     "@babel/preset-env": "7.10.3",
     "@babel/preset-react": "7.10.1",
     "@babel/preset-typescript": "^7.10.1",
-    "@slack/web-api": "^5.11.0",
+    "@slack/web-api": "^5.12.0",
     "@types/jest": "^26.0.3",
     "@types/lodash": "^4.14.157",
     "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -460,6 +460,37 @@ Hot code review alert! :thermometer:
 }
 `;
 
+exports[`slack jsx renders a simple checkbox 1`] = `
+Object {
+  "action_id": "action1",
+  "options": Array [
+    Object {
+      "description": Object {
+        "emoji": true,
+        "text": "description",
+        "type": "plain_text",
+      },
+      "text": Object {
+        "emoji": false,
+        "text": "option 1",
+        "type": "plain_text",
+      },
+      "value": "value1",
+    },
+    Object {
+      "text": Object {
+        "emoji": false,
+        "text": "option 2",
+        "type": "plain_text",
+      },
+      "url": "https://botany.io",
+      "value": "value2",
+    },
+  ],
+  "type": "checkboxes",
+}
+`;
+
 exports[`slack jsx renders a simple multi-select 1`] = `
 Object {
   "action_id": "action1",

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -22,6 +22,7 @@ import {
   MultiSelectElement,
   Home,
   ActionsBlockProps,
+  CheckboxElement,
   FC,
 } from '..';
 
@@ -473,6 +474,30 @@ describe('slack jsx', () => {
           {
             text: <PlainText>option 2</PlainText>,
             value: 'value2',
+          },
+        ]}
+      />
+    );
+
+    console.log(JSON.stringify(await render(message), null, 2));
+
+    expect(await render(message)).toMatchSnapshot();
+  });
+
+  it('renders a simple checkbox', async () => {
+    const message = (
+      <CheckboxElement
+        actionId="action1"
+        options={[
+          {
+            text: <PlainText>option 1</PlainText>,
+            description: 'description',
+            value: 'value1',
+          },
+          {
+            text: <PlainText>option 2</PlainText>,
+            value: 'value2',
+            url: 'https://botany.io',
           },
         ]}
       />

--- a/src/components/Checkbox.ts
+++ b/src/components/Checkbox.ts
@@ -1,0 +1,21 @@
+import { Checkboxes } from '@slack/types';
+import { FC } from '..';
+import { buildInputOptions, InputOption } from './shared/inputOption';
+
+export interface CheckboxElementProps {
+  initialOptions?: InputOption[];
+  actionId: string;
+  confirm?: boolean;
+  options: InputOption[];
+}
+
+export const CheckboxElement: FC<CheckboxElementProps, Checkboxes> = ({
+  initialOptions,
+  actionId,
+  options,
+}) => ({
+  type: 'checkboxes',
+  action_id: actionId,
+  options: buildInputOptions(options),
+  initial_options: buildInputOptions(initialOptions),
+});

--- a/src/components/MultiSelectElement.ts
+++ b/src/components/MultiSelectElement.ts
@@ -1,6 +1,6 @@
 import { MultiStaticSelect } from '@slack/types';
 import { FC, SelectElementProps } from '..';
-import { InputOption } from './shared/inputOption';
+import { buildInputOptions, InputOption } from './shared/inputOption';
 
 export interface MultiSelectElementProps extends SelectElementProps {
   initialOptions?: InputOption[];
@@ -13,6 +13,6 @@ export const MultiSelectElement: FC<
   type: 'multi_static_select',
   placeholder,
   action_id: actionId,
-  options,
-  initial_options: initialOptions,
+  options: buildInputOptions(options),
+  initial_options: buildInputOptions(initialOptions),
 });

--- a/src/components/SingleSelectElement.ts
+++ b/src/components/SingleSelectElement.ts
@@ -1,7 +1,6 @@
 import { StaticSelect, PlainTextElement } from '@slack/types';
 import { FC } from '..';
-import { AnyText } from './AnyText';
-import { InputOption } from './shared/inputOption';
+import { buildInputOptions, InputOption } from './shared/inputOption';
 
 export interface SelectElementProps {
   placeholder: PlainTextElement;
@@ -20,6 +19,6 @@ export const SingleSelectElement: FC<
   type: 'static_select',
   placeholder,
   action_id: actionId,
-  options,
-  initial_option: initialOption,
+  options: buildInputOptions(options),
+  initial_option: buildInputOptions([initialOption])[0],
 });

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -23,7 +23,7 @@ export type MessageText<P extends TextProps, E extends MessageTextSpec> = FC<
   E
 >;
 
-export const joinTextChildren = (children: string | string[]) => {
+export const joinTextChildren = (children: string | string[]): string => {
   // console.log('TEXT CHILDREN', children);
   return [].concat(children).join('');
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ export * from './PlainTextInputElement';
 export * from './ChannelsSelect';
 export * from './SingleSelectElement';
 export * from './MultiSelectElement';
+export * from './Checkbox';
 
 export * from './PlainText';
 export * from './MarkdownText';

--- a/src/components/shared/inputOption.ts
+++ b/src/components/shared/inputOption.ts
@@ -1,9 +1,30 @@
-import { PlainTextElement } from '@slack/types';
+import { Option } from '@slack/types';
 import { AnyText } from '../AnyText';
 
 export interface InputOption {
   text: ReturnType<AnyText>;
   value?: string;
-  description?: PlainTextElement;
+  description?: string;
   url?: string;
 }
+
+export const buildInputOptions = (inputOptions: InputOption[]): Option[] =>
+  inputOptions?.map(inputOption => {
+    const option: Option = {
+      text: inputOption.text,
+    };
+    if (inputOption.url) {
+      option.url = inputOption.url;
+    }
+    if (inputOption.value) {
+      option.value = inputOption.value;
+    }
+    if (inputOption.description) {
+      option.description = {
+        text: inputOption.description,
+        type: 'plain_text',
+        emoji: true,
+      };
+    }
+    return option;
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,15 +1405,20 @@
   dependencies:
     "@types/node" ">=8.9.0"
 
-"@slack/types@1.7.0", "@slack/types@^1.7.0":
+"@slack/types@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@slack/types/-/types-1.9.0.tgz#aa8f90b2f66ac54a77e42606644366f93cff4871"
+  integrity sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w==
+
+"@slack/types@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.7.0.tgz#0a00b60bc6703c1413edd823dcb0f829d16457ed"
   integrity sha512-aigLPmTO513JxeFyeII/74y+S5jU39tabDWPsZyMHJWCYqK3vCkRvV73NL+Ay+Tq5RC2NgSmkedk1wvQJ6oXLg==
 
-"@slack/web-api@^5.11.0":
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-5.11.0.tgz#6549ec71d13c2837cc672cbf7793a88eef22802f"
-  integrity sha512-4a/uj7IZjFLu7Qmq0nH74ecLqk1iI/9x3yRS/v6M5vXDyc5lEruRFp4d5/bz4eN5Bathlq4Bws0wioY516fPag==
+"@slack/web-api@^5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@slack/web-api/-/web-api-5.12.0.tgz#1de5e660f20fa64091bcc73eb41e3c1d3ae8e13c"
+  integrity sha512-ygSnNHVid7PltGo7W36f2SNVHyliemkzxn9uSwgnWNF7CHmWBKWAylU/eoDml9l5K7akMOxbousiurOw4XqOFg==
   dependencies:
     "@slack/logger" ">=1.0.0 <3.0.0"
     "@slack/types" "^1.7.0"


### PR DESCRIPTION
add `<Checkbox />` component for use in home tabs and modals
https://api.slack.com/reference/block-kit/block-elements#checkboxes

example:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/16813106/95004403-6fe2b700-059f-11eb-869c-193509225aa3.png">

closes: #45 