### PR TITLE
add ConversationsSelect component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -374,6 +374,29 @@ Object {
 }
 `;
 
+exports[`slack jsx renders ChannelsSelect 1`] = `
+Object {
+  "action_id": "channels-action-id",
+  "placeholder": Object {
+    "text": "",
+    "type": "plain_text",
+  },
+  "type": "channels_select",
+}
+`;
+
+exports[`slack jsx renders ConversationsSelect 1`] = `
+Object {
+  "action_id": "conversations-action-id",
+  "placeholder": Object {
+    "text": "",
+    "type": "plain_text",
+  },
+  "response_url_enabled": true,
+  "type": "conversations_select",
+}
+`;
+
 exports[`slack jsx renders Home view 1`] = `
 Object {
   "blocks": Array [

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -25,7 +25,11 @@ import {
   CheckboxElement,
   FC,
 } from '..';
-import { RadioButtonsElement } from '../components';
+import {
+  RadioButtonsElement,
+  ConversationsSelect,
+  ChannelSelect,
+} from '../components';
 
 const fakePromise = async () => Promise.resolve();
 
@@ -536,6 +540,21 @@ describe('slack jsx', () => {
           <MarkdownText>this is a test{'\n'}this too is a test</MarkdownText>
         </SectionBlock>
       </Home>
+    );
+    expect(await render(message)).toMatchSnapshot();
+  });
+
+  it('renders ChannelsSelect', async () => {
+    const message = <ChannelSelect actionId="channels-action-id" />;
+    expect(await render(message)).toMatchSnapshot();
+  });
+
+  it('renders ConversationsSelect', async () => {
+    const message = (
+      <ConversationsSelect
+        responseUrlEnabled={true}
+        actionId="conversations-action-id"
+      />
     );
     expect(await render(message)).toMatchSnapshot();
   });

--- a/src/components/ConversationsSelect.ts
+++ b/src/components/ConversationsSelect.ts
@@ -5,7 +5,7 @@ import { FC } from '..';
 
 export interface ConversationSelectProps extends ContainerProps<string> {
   initialConversation?: string;
-  actionId?: string;
+  actionId: string;
   responseUrlEnabled?: boolean;
 }
 

--- a/src/components/ConversationsSelect.ts
+++ b/src/components/ConversationsSelect.ts
@@ -1,0 +1,36 @@
+import { joinTextChildren } from './Text';
+import { ConversationsSelect as ConversationsSelectSpec } from '@slack/types';
+import { ContainerProps } from './ContainerProps';
+import { FC } from '..';
+
+export interface ConversationSelectProps extends ContainerProps<string> {
+  initialConversation?: string;
+  actionId?: string;
+  responseUrlEnabled?: boolean;
+}
+
+export const ConversationsSelect: FC<
+  ConversationSelectProps,
+  ConversationsSelectSpec
+> = ({
+  children,
+  initialConversation,
+  actionId,
+  responseUrlEnabled = false,
+}) => {
+  const select: ConversationsSelectSpec = {
+    type: 'conversations_select',
+    initial_conversation: initialConversation,
+    action_id: actionId,
+    response_url_enabled: responseUrlEnabled,
+  };
+
+  if (children) {
+    select.placeholder = {
+      type: 'plain_text',
+      text: joinTextChildren(children),
+    };
+  }
+
+  return select;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,6 +14,7 @@ export * from './ButtonElement';
 export * from './ImageElement';
 export * from './PlainTextInputElement';
 export * from './ChannelsSelect';
+export * from './ConversationsSelect';
 export * from './SingleSelectElement';
 export * from './MultiSelectElement';
 export * from './Checkbox';


### PR DESCRIPTION
add a new `<ConversationsSelect />` component for showing public/private channels a user has access to
<img width="400" alt="image" src="https://user-images.githubusercontent.com/16813106/105097012-c72c6a80-5a5c-11eb-9e1e-67e5bda31b78.png">

closes: #55 
