### PR TITLE
Feature/57 select menu option groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -483,6 +483,80 @@ Hot code review alert! :thermometer:
 }
 `;
 
+exports[`slack jsx renders a multi-select with option_groups 1`] = `
+Object {
+  "action_id": "action1",
+  "initial_options": Array [
+    Object {
+      "text": Object {
+        "emoji": false,
+        "text": "option 1",
+        "type": "plain_text",
+      },
+      "value": "value1",
+    },
+  ],
+  "option_groups": Array [
+    Object {
+      "label": Object {
+        "emoji": false,
+        "text": "Group 1",
+        "type": "plain_text",
+      },
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 1",
+            "type": "plain_text",
+          },
+          "value": "value1",
+        },
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 2",
+            "type": "plain_text",
+          },
+          "value": "value2",
+        },
+      ],
+    },
+    Object {
+      "label": Object {
+        "emoji": false,
+        "text": "Group 2",
+        "type": "plain_text",
+      },
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 1",
+            "type": "plain_text",
+          },
+          "value": "value3",
+        },
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 2",
+            "type": "plain_text",
+          },
+          "value": "value4",
+        },
+      ],
+    },
+  ],
+  "placeholder": Object {
+    "emoji": false,
+    "text": "placeholder text",
+    "type": "plain_text",
+  },
+  "type": "multi_static_select",
+}
+`;
+
 exports[`slack jsx renders a radiobutton group 1`] = `
 Object {
   "action_id": "action1",
@@ -625,6 +699,78 @@ Object {
         "type": "plain_text",
       },
       "value": "value2",
+    },
+  ],
+  "placeholder": Object {
+    "emoji": false,
+    "text": "placeholder text",
+    "type": "plain_text",
+  },
+  "type": "static_select",
+}
+`;
+
+exports[`slack jsx renders a single-select with option_groups 1`] = `
+Object {
+  "action_id": "action1",
+  "initial_option": Object {
+    "text": Object {
+      "emoji": false,
+      "text": "option 1",
+      "type": "plain_text",
+    },
+    "value": "value1",
+  },
+  "option_groups": Array [
+    Object {
+      "label": Object {
+        "emoji": false,
+        "text": "Group 1",
+        "type": "plain_text",
+      },
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 1",
+            "type": "plain_text",
+          },
+          "value": "value1",
+        },
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 2",
+            "type": "plain_text",
+          },
+          "value": "value2",
+        },
+      ],
+    },
+    Object {
+      "label": Object {
+        "emoji": false,
+        "text": "Group 2",
+        "type": "plain_text",
+      },
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 1",
+            "type": "plain_text",
+          },
+          "value": "value3",
+        },
+        Object {
+          "text": Object {
+            "emoji": false,
+            "text": "option 2",
+            "type": "plain_text",
+          },
+          "value": "value4",
+        },
+      ],
     },
   ],
   "placeholder": Object {

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -462,6 +462,53 @@ describe('slack jsx', () => {
     expect(await render(message)).toMatchSnapshot();
   });
 
+  it('renders a multi-select with option_groups', async () => {
+    const message = (
+      <MultiSelectElement
+        actionId="action1"
+        placeholder={<PlainText>placeholder text</PlainText>}
+        initialOptions={[
+          {
+            text: <PlainText>option 1</PlainText>,
+            value: 'value1',
+          },
+        ]}
+        optionGroups={[
+          {
+            label: <PlainText>Group 1</PlainText>,
+            options: [
+              {
+                text: <PlainText>option 1</PlainText>,
+                value: 'value1',
+              },
+              {
+                text: <PlainText>option 2</PlainText>,
+                value: 'value2',
+              },
+            ],
+          },
+          {
+            label: <PlainText>Group 2</PlainText>,
+            options: [
+              {
+                text: <PlainText>option 1</PlainText>,
+                value: 'value3',
+              },
+              {
+                text: <PlainText>option 2</PlainText>,
+                value: 'value4',
+              },
+            ],
+          },
+        ]}
+      />
+    );
+
+    console.log(JSON.stringify(await render(message), null, 2));
+
+    expect(await render(message)).toMatchSnapshot();
+  });
+
   it('renders a simple single-select', async () => {
     const message = (
       <SingleSelectElement
@@ -479,6 +526,48 @@ describe('slack jsx', () => {
           {
             text: <PlainText>option 2</PlainText>,
             value: 'value2',
+          },
+        ]}
+      />
+    );
+    expect(await render(message)).toMatchSnapshot();
+  });
+
+  it('renders a single-select with option_groups', async () => {
+    const message = (
+      <SingleSelectElement
+        actionId="action1"
+        initialOption={{
+          text: <PlainText>option 1</PlainText>,
+          value: 'value1',
+        }}
+        placeholder={<PlainText>placeholder text</PlainText>}
+        optionGroups={[
+          {
+            label: <PlainText>Group 1</PlainText>,
+            options: [
+              {
+                text: <PlainText>option 1</PlainText>,
+                value: 'value1',
+              },
+              {
+                text: <PlainText>option 2</PlainText>,
+                value: 'value2',
+              },
+            ],
+          },
+          {
+            label: <PlainText>Group 2</PlainText>,
+            options: [
+              {
+                text: <PlainText>option 1</PlainText>,
+                value: 'value3',
+              },
+              {
+                text: <PlainText>option 2</PlainText>,
+                value: 'value4',
+              },
+            ],
           },
         ]}
       />

--- a/src/components/MultiSelectElement.ts
+++ b/src/components/MultiSelectElement.ts
@@ -9,10 +9,16 @@ export interface MultiSelectElementProps extends SelectElementProps {
 export const MultiSelectElement: FC<
   MultiSelectElementProps,
   MultiStaticSelect
-> = ({ placeholder, actionId, options, initialOptions }) => ({
+> = ({ placeholder, actionId, options, optionGroups, initialOptions }) => ({
   type: 'multi_static_select',
   placeholder,
   action_id: actionId,
-  options: buildInputOptions(options),
+  ...(options && { options: buildInputOptions(options) }),
+  ...(optionGroups && {
+    option_groups: optionGroups.map(group => ({
+      label: group.label,
+      options: buildInputOptions(group.options),
+    })),
+  }),
   initial_options: buildInputOptions(initialOptions),
 });

--- a/src/components/SingleSelectElement.ts
+++ b/src/components/SingleSelectElement.ts
@@ -5,7 +5,8 @@ import { buildInputOptions, InputOption } from './shared/inputOption';
 export interface SelectElementProps {
   placeholder: PlainTextElement;
   actionId: string;
-  options: InputOption[];
+  options?: InputOption[];
+  optionGroups?: { label: PlainTextElement; options: InputOption[] }[];
 }
 
 export interface SingleSelectElementProps extends SelectElementProps {
@@ -15,10 +16,16 @@ export interface SingleSelectElementProps extends SelectElementProps {
 export const SingleSelectElement: FC<
   SingleSelectElementProps,
   StaticSelect
-> = ({ placeholder, actionId, options, initialOption }) => ({
+> = ({ placeholder, actionId, options, optionGroups, initialOption }) => ({
   type: 'static_select',
   placeholder,
   action_id: actionId,
-  options: buildInputOptions(options),
+  ...(options && { options: buildInputOptions(options) }),
+  ...(optionGroups && {
+    option_groups: optionGroups.map(group => ({
+      label: group.label,
+      options: buildInputOptions(group.options),
+    })),
+  }),
   initial_option: buildInputOptions([initialOption])[0],
 });


### PR DESCRIPTION
closes: #57 

allow using either `options` or `option_groups` in select menus

### using `options`
![image](https://user-images.githubusercontent.com/16813106/105109683-e1bd0e80-5a71-11eb-937f-70dd03803862.png)

### using `option_groups`
![image](https://user-images.githubusercontent.com/16813106/105109652-d0740200-5a71-11eb-9b72-40b1f53c4d99.png)
