### PR TITLE
allow filtering conversations list by type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -397,6 +397,37 @@ Object {
 }
 `;
 
+exports[`slack jsx renders ConversationsSelect with filter 1`] = `
+Object {
+  "action_id": "conversations-action-id",
+  "filter": Object {
+    "exclude_bot_users": undefined,
+    "exclude_external_shared_channels": undefined,
+    "include": Array [
+      "public",
+    ],
+  },
+  "placeholder": Object {
+    "text": "",
+    "type": "plain_text",
+  },
+  "response_url_enabled": true,
+  "type": "conversations_select",
+}
+`;
+
+exports[`slack jsx renders ConversationsSelect with no filter 1`] = `
+Object {
+  "action_id": "conversations-action-id",
+  "placeholder": Object {
+    "text": "",
+    "type": "plain_text",
+  },
+  "response_url_enabled": true,
+  "type": "conversations_select",
+}
+`;
+
 exports[`slack jsx renders Home view 1`] = `
 Object {
   "blocks": Array [

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -638,11 +638,22 @@ describe('slack jsx', () => {
     expect(await render(message)).toMatchSnapshot();
   });
 
-  it('renders ConversationsSelect', async () => {
+  it('renders ConversationsSelect with no filter', async () => {
     const message = (
       <ConversationsSelect
         responseUrlEnabled={true}
         actionId="conversations-action-id"
+      />
+    );
+    expect(await render(message)).toMatchSnapshot();
+  });
+
+  it('renders ConversationsSelect with filter', async () => {
+    const message = (
+      <ConversationsSelect
+        responseUrlEnabled={true}
+        actionId="conversations-action-id"
+        filter={{ include: ['public'] }}
       />
     );
     expect(await render(message)).toMatchSnapshot();

--- a/src/components/ConversationsSelect.ts
+++ b/src/components/ConversationsSelect.ts
@@ -6,6 +6,13 @@ import { FC } from '..';
 export interface ConversationSelectProps extends ContainerProps<string> {
   initialConversation?: string;
   actionId: string;
+  filter?: {
+    include?: ('im' | 'mpim' | 'private' | 'public')[];
+    excludeExternalSharedChannels?: boolean;
+    excludeBotUsers?: boolean;
+  };
+  exclude_external_shared_channels?: boolean;
+  exclude_bot_users?: boolean;
   responseUrlEnabled?: boolean;
 }
 
@@ -16,6 +23,7 @@ export const ConversationsSelect: FC<
   children,
   initialConversation,
   actionId,
+  filter,
   responseUrlEnabled = false,
 }) => {
   const select: ConversationsSelectSpec = {
@@ -23,6 +31,13 @@ export const ConversationsSelect: FC<
     initial_conversation: initialConversation,
     action_id: actionId,
     response_url_enabled: responseUrlEnabled,
+    ...(filter && {
+      filter: {
+        include: filter.include,
+        exclude_bot_users: filter.excludeBotUsers,
+        exclude_external_shared_channels: filter.excludeExternalSharedChannels,
+      },
+    }),
   };
 
   if (children) {


### PR DESCRIPTION
support the filters slack provides including
* conversation type
* shared channels
* bot users

in the `<ConversationsSelect />` component 