### PR TITLE
change time_picker to timepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-renderer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "scripts": {
     "postversion": "npm publish",

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -446,7 +446,7 @@ Object {
     "text": "placeholder text",
     "type": "plain_text",
   },
-  "type": "time_picker",
+  "type": "timepicker",
 }
 `;
 

--- a/src/components/TimePicker.ts
+++ b/src/components/TimePicker.ts
@@ -5,7 +5,7 @@ export interface TimePickerSpec {
   initial_time?: string;
   placeholder: PlainTextElement;
   action_id: string;
-  type: 'time_picker';
+  type: 'timepicker';
 }
 
 export interface TimePickerElementProps {
@@ -19,7 +19,7 @@ export const TimePickerElement: FC<TimePickerElementProps, TimePickerSpec> = ({
   actionId,
   placeholder,
 }) => ({
-  type: 'time_picker',
+  type: 'timepicker',
   action_id: actionId,
   initial_time: initialTime,
   placeholder,


### PR DESCRIPTION
it appears that the beta feature `time_picker` has changed names to `timepicker`. you can see the error when trying to render the view using a time picker showing

>[ERROR] unsupported type: time_picker 

you can see in [block-kit-builder](https://app.slack.com/block-kit-builder/TQH41TCAG#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Section%20block%20with%20a%20timepicker%22%7D,%22accessory%22:%7B%22type%22:%22timepicker%22,%22initial_time%22:%2213:37%22,%22placeholder%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Select%20time%22,%22emoji%22:true%7D,%22action_id%22:%22timepicker-action%22%7D%7D%5D%7D) that the name is currently `timepicker` 